### PR TITLE
Adicionado envio de email com destinatário default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - DATABASE_SSL=false
       - DATABASE_AUTHENTICATION_DATABASE=admin
       - HOST=localhost
+      - DEFAULT_EMAIL=contato@dc.ufscar.br
     volumes:
       - ./api-config:/usr/src/api/api-config
       - ./backup/uploads:/usr/src/api/backup/uploads

--- a/strapi-app/plugins/email/controllers/Email.js
+++ b/strapi-app/plugins/email/controllers/Email.js
@@ -4,18 +4,10 @@
  * Email.js controller
  *
  * @description: A set of functions called "actions" of the `email` plugin.
+teste
  */
 
 const _ = require('lodash');
-var nodemailer = require('nodemailer');
-
-var transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.user_email,
-    pass: process.env.user_password,
-  }
-});
 
 module.exports = {
   send: async (ctx) => {
@@ -37,23 +29,11 @@ module.exports = {
       return;
     }
 
-    let options = ctx.request.body;
+    let options = {...ctx.request.body, to:process.env.DEFAULT_EMAIL};
 
-    var mailOptions = {
-       from: process.env.user_email,
-       to: config.sendmail_default_replyto,
-       subject: 'Site DC:'+ctx.request.body.subject,
-       text: 'Nome: '+ctx.request.body.name+'\nEmail: '+ctx.request.body.email+'Mensagem: '+ctx.request.body.text,
-    };
+    await strapi.plugins.email.services.email.send(options, config);
 
-    transporter.sendMail(mailOptions, function(error, info){
-      if (error) {
-        console.log(error);
-      } else {
-        console.log('Email sent: ' + info.response);
-      }
-    }); 
-
+    // Send 200 `ok`
     ctx.send({});
   },
 
@@ -87,4 +67,3 @@ module.exports = {
     ctx.send({ok: true});
   },
 };
-


### PR DESCRIPTION
- Voltei para o arquivo inicial do `strapi-app/plugins/email/controllers/Email.js` e em cima disso modifiquei para enviar o e-mail para apenas um único destinatário (antes na requisição você dizia para quem iria enviar o email).
- Criei uma variável de ambiente para determinar para qual e-mail as mensagens devem ser encaminhadas

Observação: é necessário instalar o plugin do send-grind (`npm install strapi-provider-email-sendgrid@alpha --save`), como não consegui, fica aí um pequeno débito.